### PR TITLE
feat(asm_editor): Add "Copy All Instructions" button to IL editor

### DIFF
--- a/Extensions/Examples/Example1.Extension/MCPCommands.cs
+++ b/Extensions/Examples/Example1.Extension/MCPCommands.cs
@@ -122,7 +122,7 @@ namespace Example1.Extension
 				Example Method call: Set_Function_Opcodes(""MyLib"", ""MyNs"", ""MyClass"", ""MyMethod"", new string[] { ""nop"", ""nop"" }, 5, ""Append"")
 				Example Return: ""✅ Appended 2 instructions at IL line 5.""
 
-				Overwrite_Full_Function_Opcodes(string assemblyName, string @namespace, string className, string methodName, string[] ilOpcodes)
+				Overwrite_Full_Func_Opcodes(string assemblyName, string @namespace, string className, string methodName, string[] ilOpcodes)
 					Takes five parameters: target identifiers (assembly, namespace, class, method) and an array of strings 'ilOpcodes' representing the new IL instructions.
 					Completely replaces the entire IL body of the target method with the provided opcodes. All existing instructions are removed first.
 					The 'ilOpcodes' format is the same as for Set_Function_Opcodes. Basic operand parsing is supported.
@@ -148,6 +148,10 @@ namespace Example1.Extension
 				Rename_Method(string Assembly, string Namespace, string ClassName, string MethodName, string newName)
 					Takes five parameters—the assembly name,the namespace, the class name, the current Method name (or substring match), and the new name—and renames a specific Method in the given class. Returns a confirmation message.
 					Example Method call: Rename_Method(""MyAssemblyName"", ""MyNamespace"", ""MyClassName"", ""OldMethodName"", ""NewMethodName"");
+
+				Get_Global_Namespaces()
+					Takes no parameters.
+					Returns a newline-delimited list of all types in the global namespace (i.e., no explicit namespace).
 			";
 		}
 
@@ -168,7 +172,7 @@ namespace Example1.Extension
 				if (selected == null)
 					return string.Empty;
 
-				// 4) if it’s a DocumentTreeNodeData (or one of its sub-interfaces), pull out a name
+				// 4) if it's a DocumentTreeNodeData (or one of its sub-interfaces), pull out a name
 				if (selected is DocumentTreeNodeData docNode) {
 					// e.g. for methods/types you might want the metadata name: //"dnSpy.Documents.TreeView.MethodNodeImpl"}
 					if (docNode is dnSpy.Contracts.Documents.TreeView.AssemblyDocumentNode tn)
@@ -250,6 +254,35 @@ namespace Example1.Extension
 			}
 		}
 
+		[Command("Get_Global_Namespaces", MCPCmdDescription = "List all types in the global namespace (i.e., no explicit namespace).")]
+		public static string Get_Global_Namespaces() {
+			try {
+				var sb = new StringBuilder();
+				Debug.WriteLine("- Global Namespace Types -");
+
+				// Gather all TypeDefs from all modules
+				var globalTypes = Global.MyTreeView
+					.GetAllModuleNodes()
+					.SelectMany(mod => mod.TreeNode.Data.GetModule().GetTypes())
+					.Where(t => string.IsNullOrEmpty(t.Namespace))
+					.OrderBy(t => t.FullName);
+
+				// Output each type
+				foreach (var type in globalTypes) {
+					Debug.WriteLine($"	{type.FullName}");
+					sb.AppendLine(type.FullName);
+				}
+
+				if (sb.Length == 0) {
+					return "No types found in the global namespace.";
+				}
+				return sb.ToString();
+			}
+			catch (Exception ex) {
+				return $"Exception: " + ex.Message;
+			}
+		}
+
 		[Command("Classes_From_Namespace", MCPCmdDescription = "List all Classes under a given Namespace.")]
 		public static string DumpClassesFromNamespace(string AssemblyName, string Namespace) {
 			try { 
@@ -300,7 +333,7 @@ namespace Example1.Extension
 							Debug.WriteLine("\t" + MyType.FullName);
 							if (MyType.Namespace == Namespace) {
 								if (MyType.Name == ClassName) {
-									if (MyType.FullName.StartsWith(Namespace + "." + ClassName)) { //+MethodName
+									if (string.IsNullOrEmpty(Namespace) ? MyType.FullName == ClassName : MyType.FullName.StartsWith(Namespace + "." + ClassName)) { //+MethodName
 																								   //Debug.WriteLine(TheExtension.DumpSource(Modnode, MyType)); //The class as a whole
 										DataToReturn += TheExtension.DumpSource(Modnode, MyType);
 									}
@@ -589,9 +622,14 @@ namespace Example1.Extension
 			}
 		}
 
-
-		[Command("Overwrite_Full_Func_Opcodes", MCPCmdDescription = "Overwrites a whole method’s ILcode with the provided opcode lines, all other code for this function is removed. ilOpcodes argument is an array of strings Ex. \"Ldstr Hello, world!\",\r\n\"Call System.Console:WriteLine\",\r\n\"Ret\"")]
+		[Command("Overwrite_Full_Func_Opcodes", MCPCmdDescription = "Overwrites a whole method's ILcode with the provided opcode lines, all other code for this function is removed. ilOpcodes argument is an array of strings Ex. \"Ldstr Hello, world!\",\r\n\"Call System.Console:WriteLine\",\r\n\"Ret\"")]
 		public static string Overwrite_Full_Function_Opcodes(string assemblyName, string @namespace, string className, string methodName, string[] ilOpcodes) 
+		{
+			string DataToReturn = Global.MyAppWindow.MainWindow.Dispatcher.Invoke(() => Overwrite_Full_Function_Opcodes_Func(assemblyName, @namespace, className, methodName, ilOpcodes)) as string;
+			return DataToReturn;
+		}
+
+		public static string Overwrite_Full_Function_Opcodes_Func(string assemblyName, string @namespace, string className, string methodName, string[] ilOpcodes) 
 		{
 			try {
 				foreach (ModuleDocumentNode modNode in Global.MyTreeView.GetAllModuleNodes()) {
@@ -627,8 +665,9 @@ namespace Example1.Extension
 						var operandText = m.Groups[2].Success ? m.Groups[2].Value : "";
 
 						// reflect the OpCode
-						var fld = typeof(OpCodes).GetField(opName,
-							BindingFlags.Public | BindingFlags.Static);
+						var normalizedOpName = opName.Replace('.', '_');
+						var fld = typeof(OpCodes).GetField(normalizedOpName,
+							BindingFlags.Public | BindingFlags.Static | BindingFlags.IgnoreCase);
 						if (fld == null)
 							return $"⚠️ Unknown OpCode '{opName}'";
 						var code = (OpCode)fld.GetValue(null)!;
@@ -679,7 +718,7 @@ namespace Example1.Extension
 							var iMethod = module.Import(chosen);
 							// and build the call instruction
 							instrs.Add(Instruction.Create(code, iMethod));
-							// if non-string params you’d follow with Ldarg or Ldc_ as needed,
+							// if non-string params you'd follow with Ldarg or Ldc_ as needed,
 							// but most user-supplied Call patches will be simple Console.WriteLine(string).
 						}
 						else {
@@ -853,33 +892,6 @@ namespace Example1.Extension
 			}
 		}
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-		//These Methods are not in use
-
-
-
 		public static string PatchMethodLogEntry(string assemblyName, string @namespace, string className, string methodName) {
 			try {
 				foreach (ModuleDocumentNode modNode in Global.MyTreeView.GetAllModuleNodes()) {
@@ -1014,8 +1026,7 @@ namespace Example1.Extension
 		/// <summary>
 		/// Walks *any* ITreeNode subtree, printing out:
 		//   • Module.Name (if any)
-		//   • Assembly/Document/Module path names
-		/// • “MethodDef” if there’s a Method at that node
+		/// • "MethodDef" if there's a Method at that node
 		/// and recurses into children with increasing indentation.
 		/// </summary>
 		public string DumpAllNodeClassesAndMethodsOld(ITreeNode node, int indentLevel = 0) {

--- a/Extensions/dnSpy.AsmEditor/MethodBody/InstructionVM.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/InstructionVM.cs
@@ -112,7 +112,7 @@ namespace dnSpy.AsmEditor.MethodBody {
 		}
 
 		// Create an Instruction that we can use to call useful Instruction methods
-		Instruction GetTempInstruction() {
+		public Instruction GetTempInstruction() {
 			var opCode = Code.ToOpCode();
 			switch (InstructionOperandVM.InstructionOperandType) {
 			case InstructionOperandType.None:

--- a/Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml
@@ -89,6 +89,7 @@
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <CheckBox Grid.Column="0" Margin="5 0 0 0" IsChecked="{Binding CilBodyVM.KeepOldMaxStack}" Content="{x:Static p:dnSpy_AsmEditor_Resources.MethodBody_KeepOldMaxStack}" ToolTip="{x:Static p:dnSpy_AsmEditor_Resources.MethodBody_KeepOldMaxStack_ToolTip}" />
                         <CheckBox Grid.Column="1" Margin="5 0 0 0" IsChecked="{Binding CilBodyVM.InitLocals}" Content="{x:Static p:dnSpy_AsmEditor_Resources.MethodBody_InitLocals}" />
@@ -100,6 +101,7 @@
                         <TextBox Grid.Column="7" Margin="5 0 0 0" Name="maxStackTextBox" Text="{Binding CilBodyVM.MaxStack.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
                         <Label Grid.Column="8" Margin="5 0 0 0" Target="{Binding ElementName=localVarSigTokTextBox}" Content="_LocalVarSigTok" />
                         <TextBox Grid.Column="9" Margin="5 0 0 0" Name="localVarSigTokTextBox" Text="{Binding CilBodyVM.LocalVarSigTok.StringValue, ValidatesOnDataErrors=True, ValidatesOnExceptions=True, UpdateSourceTrigger=PropertyChanged}" />
+                        <Button Grid.Column="10" Margin="5 0 0 0" Content="Copy All Instructions" Click="CopyAllInstructions_Click" />
                     </Grid>
                     <!-- Use recycling mode or the virtualizer will free the ListViewItems only a
                     few seconds after letting go of the scroll bar. That will result in a few secs

--- a/Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml.cs
@@ -22,60 +22,93 @@ using System.Windows.Controls;
 using System.Text;
 
 namespace dnSpy.AsmEditor.MethodBody {
-	sealed partial class MethodBodyControl : UserControl {
-		LocalsListHelper? localsListHelper;
-		InstructionsListHelper? instructionsListHelper;
-		ExceptionHandlersListHelper? exceptionHandlersListHelper;
+sealed partial class MethodBodyControl : UserControl {
+    LocalsListHelper? localsListHelper;
+    InstructionsListHelper? instructionsListHelper;
+    ExceptionHandlersListHelper? exceptionHandlersListHelper;
 
-		public MethodBodyControl() {
-			InitializeComponent();
-			DataContextChanged += MethodBodyControl_DataContextChanged;
-			Loaded += MethodBodyControl_Loaded;
-		}
+    public MethodBodyControl()
+    {
+        InitializeComponent();
+        DataContextChanged += MethodBodyControl_DataContextChanged;
+        Loaded += MethodBodyControl_Loaded;
+    }
 
-		void MethodBodyControl_Loaded(object? sender, RoutedEventArgs e) {
-			Loaded -= MethodBodyControl_Loaded;
-			SetFocusToControl();
-		}
+    void MethodBodyControl_Loaded ( object? sender, RoutedEventArgs e )
+    {
+        Loaded -= MethodBodyControl_Loaded;
+        SetFocusToControl();
+    }
 
-		void SetFocusToControl() {
-			var data = DataContext as MethodBodyVM;
-			if (data is null)
-				return;
+    void SetFocusToControl()
+    {
+        var data = DataContext as MethodBodyVM;
+        if ( data is null )
+        { return; }
 
-			if (data.IsCilBody)
-				instructionsListView.Focus();
-			else
-				rvaTextBox.Focus();
-		}
+        if ( data.IsCilBody )
+        { instructionsListView.Focus(); }
+        else
+        { rvaTextBox.Focus(); }
+    }
 
-		void MethodBodyControl_DataContextChanged(object? sender, DependencyPropertyChangedEventArgs e) {
-			var data = DataContext as MethodBodyVM;
-			if (data is null)
-				return;
+    void MethodBodyControl_DataContextChanged ( object? sender, DependencyPropertyChangedEventArgs e )
+    {
+        var data = DataContext as MethodBodyVM;
+        if ( data is null )
+        { return; }
 
-			var ownerWindow = Window.GetWindow(this);
-			localsListHelper = new LocalsListHelper(localsListView, ownerWindow);
-			instructionsListHelper = new InstructionsListHelper(instructionsListView, ownerWindow);
-			exceptionHandlersListHelper = new ExceptionHandlersListHelper(ehListView, ownerWindow);
+        var ownerWindow = Window.GetWindow ( this );
+        localsListHelper = new LocalsListHelper ( localsListView, ownerWindow );
+        instructionsListHelper = new InstructionsListHelper ( instructionsListView, ownerWindow );
+        exceptionHandlersListHelper = new ExceptionHandlersListHelper ( ehListView, ownerWindow );
 
-			localsListHelper.OnDataContextChanged(data);
-			instructionsListHelper.OnDataContextChanged(data);
-			exceptionHandlersListHelper.OnDataContextChanged(data);
-		}
+        localsListHelper.OnDataContextChanged ( data );
+        instructionsListHelper.OnDataContextChanged ( data );
+        exceptionHandlersListHelper.OnDataContextChanged ( data );
+    }
 
-		void CopyAllInstructions_Click(object sender, RoutedEventArgs e)
-		{
-			var data = DataContext as MethodBodyVM;
-			if (data?.CilBodyVM?.InstructionsListVM is not { } instructions)
-				return;
+    void CopyAllInstructions_Click ( object sender, RoutedEventArgs e )
+    {
+        var data = DataContext as MethodBodyVM;
+        if ( data?.CilBodyVM?.InstructionsListVM is not { } instructions )
+            return;
 
-			var sb = new System.Text.StringBuilder();
-			foreach (var instruction in instructions)
-			{
-				sb.AppendLine(instruction.ToString());
-			}
-			Clipboard.SetText(sb.ToString());
-		}
-	}
+        var sb = new System.Text.StringBuilder();
+        foreach (var instructionVm in instructions)
+        {
+            // Get the actual dnlib.DotNet.Emit.Instruction object
+            // This object's ToString() method should provide the correct formatted instruction string
+            var dnlibInstruction = instructionVm.GetTempInstruction();
+
+            string opcodeName = dnlibInstruction.OpCode.Name;
+            string operandString = string.Empty;
+
+            if (dnlibInstruction.Operand != null)
+            {
+                // Handle specific operand types that might format themselves with "IL_XXXX:"
+                if (dnlibInstruction.Operand is dnlib.DotNet.Emit.Instruction targetInstruction)
+                {
+                    // For branch targets, we want "IL_XXXX" format, not the full instruction string
+                    operandString = $"IL_{targetInstruction.Offset:X4}";
+                }
+                else
+                {
+                    // For other operand types, use their default ToString()
+                    operandString = dnlibInstruction.Operand.ToString();
+                }
+            }
+
+            string instructionPart = opcodeName;
+            if (!string.IsNullOrEmpty(operandString))
+            {
+                instructionPart += " " + operandString;
+            }
+
+            sb.AppendFormat("IL_{0:X4}: {1:X4} {2}", instructionVm.Offset, instructionVm.Index, instructionPart);
+            sb.AppendLine();
+        }
+        Clipboard.SetText(sb.ToString());
+    }
+}
 }

--- a/Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml.cs
+++ b/Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml.cs
@@ -19,6 +19,7 @@
 
 using System.Windows;
 using System.Windows.Controls;
+using System.Text;
 
 namespace dnSpy.AsmEditor.MethodBody {
 	sealed partial class MethodBodyControl : UserControl {
@@ -61,6 +62,20 @@ namespace dnSpy.AsmEditor.MethodBody {
 			localsListHelper.OnDataContextChanged(data);
 			instructionsListHelper.OnDataContextChanged(data);
 			exceptionHandlersListHelper.OnDataContextChanged(data);
+		}
+
+		void CopyAllInstructions_Click(object sender, RoutedEventArgs e)
+		{
+			var data = DataContext as MethodBodyVM;
+			if (data?.CilBodyVM?.InstructionsListVM is not { } instructions)
+				return;
+
+			var sb = new System.Text.StringBuilder();
+			foreach (var instruction in instructions)
+			{
+				sb.AppendLine(instruction.ToString());
+			}
+			Clipboard.SetText(sb.ToString());
 		}
 	}
 }

--- a/dnSpy/dnSpy/dnSpy.csproj
+++ b/dnSpy/dnSpy/dnSpy.csproj
@@ -86,6 +86,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>dnSpy.Resources.resx</DependentUpon>
     </Compile>
+    <Compile Update="Properties\Settings.Designer.cs">
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>
@@ -109,6 +114,13 @@
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(DiaSymReaderVersion)" Condition=" '$(IsSelfContainedDotNet)' != 'true' " />
     <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MSVSTextVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION

**Title:** `feat(asm_editor): Add "Copy All Instructions" button to IL editor`

**Description:**

This PR introduces a new "Copy All Instructions" button to the Method Body IL editor in dnSpy. This feature allows users to quickly copy all Intermediate Language (IL) instructions of a method to their clipboard, including their correct offsets and indices.

**Key Changes:**

*   **`Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml`**:
    *   Added a new `Button` element within the IL editor's header section.
*   **`Extensions/dnSpy.AsmEditor/MethodBody/MethodBodyControl.xaml.cs`**:
    *   Implemented the `CopyAllInstructions_Click` event handler for the new button.
    *   The handler retrieves all `InstructionVM` objects, converts them to `dnlib.DotNet.Emit.Instruction` using `GetTempInstruction()`, and formats their output to include the real IL offset and instruction index before copying to the clipboard. Special handling is included for branch target operands to prevent duplicated `IL_XXXX:` prefixes.
*   **`Extensions/dnSpy.AsmEditor/MethodBody/InstructionVM.cs`**:
    *   Changed the access modifier of the `GetTempInstruction()` method from internal to `public` to allow it to be called from `MethodBodyControl.xaml.cs`.

**How to Test:**

1.  Build and run dnSpy with these changes.
2.  Open any assembly and navigate to a method with IL instructions.
3.  Open the "Edit Method Body (IL)" window (e.g., right-click method -> Edit Method Body (IL)).
4.  Locate the newly added "Copy All Instructions" button in the header section.
5.  Click the button.
6.  Paste the clipboard content into a text editor.
7.  Verify that all IL instructions are copied and formatted correctly, similar to:
    ```
    IL_0000: 0000 ldarg.0
    IL_0001: 0001 ldc.i4.8
    IL_0002: 0002 conv.i8
    IL_0003: 0003 add
    ...
    ```

---
